### PR TITLE
Upgrade to version 1.7 and add support for Protocol 1.21.6 and 1.21.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You may use this plugin in your projects, even commercially, but you may not res
 
 ## Requirements
 
-- **Spigot/Paper 1.21.4 - 1.21.5 +**
+- **Spigot/Paper 1.21.4 - 1.21.7 +**
 
 ## Commands
 
@@ -89,7 +89,7 @@ This Project uses Maven:
 <dependency>
     <groupId>de.t0bx</groupId>
     <artifactId>SentienceEntity</artifactId>
-    <version>1.6</version>
+    <version>1.7</version>
     <scope>provided</scope>
 </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.t0bx</groupId>
     <artifactId>SentienceEntity</artifactId>
-    <version>1.6</version>
+    <version>1.7</version>
     <packaging>jar</packaging>
 
     <name>SentienceEntity</name>

--- a/src/main/java/de/t0bx/sentienceEntity/commands/SentienceEntityCommand.java
+++ b/src/main/java/de/t0bx/sentienceEntity/commands/SentienceEntityCommand.java
@@ -415,8 +415,22 @@ public class SentienceEntityCommand implements CommandExecutor, TabCompleter {
                 }
             }
 
-            case "editnpc", "removenpc", "createhologram", "removehologram", "lines" -> {
+            case "removenpc", "createhologram", "removehologram", "lines" -> {
                 return npcNames;
+            }
+
+            case "editnpc" -> {
+                if (args.length == 2) {
+                    return npcNames;
+                } else if (args.length == 3) {
+                    return List.of("shouldLookAtPlayer", "shouldSneakWithPlayer", "updateLocation", "setSkin");
+                } else if (args.length == 4) {
+                    if (args[2].equalsIgnoreCase("setSkin")) {
+                        return Collections.singletonList("<Player Name>");
+                    } else {
+                        return Collections.emptyList();
+                    }
+                }
             }
 
             case "addline" -> {

--- a/src/main/java/de/t0bx/sentienceEntity/network/version/ProtocolVersion.java
+++ b/src/main/java/de/t0bx/sentienceEntity/network/version/ProtocolVersion.java
@@ -30,6 +30,7 @@
 
 package de.t0bx.sentienceEntity.network.version;
 
+import de.t0bx.sentienceEntity.SentienceEntity;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.bukkit.Bukkit;
@@ -38,7 +39,9 @@ import org.bukkit.Bukkit;
 @RequiredArgsConstructor
 public enum ProtocolVersion {
     V1_21_4("1.21.4", 	769),
-    V1_21_5("1.21.5", 770);
+    V1_21_5("1.21.5", 770),
+    V1_21_6("1.21.6", 771),
+    V1_21_7("1.21.7", 772);
 
     private final String versionString;
     private final int protocolId;
@@ -55,6 +58,8 @@ public enum ProtocolVersion {
         for (ProtocolVersion version : values()) {
             if (serverVersion.contains(version.versionString)) return version;
         }
+
+        Bukkit.getPluginManager().disablePlugin(SentienceEntity.getInstance());
         throw new IllegalStateException("SentienceEntity doesn't support Version: " + serverVersion);
     }
 }

--- a/src/main/java/de/t0bx/sentienceEntity/network/version/registries/EntityTypeRegistry.java
+++ b/src/main/java/de/t0bx/sentienceEntity/network/version/registries/EntityTypeRegistry.java
@@ -51,6 +51,14 @@ public class EntityTypeRegistry {
         v1215.put(EntityType.ARMOR_STAND, 5);
         v1215.put(EntityType.PLAYER, 148);
         REGISTRY.put(ProtocolVersion.V1_21_5, v1215);
+
+        var v1216 = new EnumMap<EntityType, Integer>(EntityType.class);
+        v1216.put(EntityType.ARMOR_STAND, 5);
+        v1216.put(EntityType.PLAYER, 149);
+        REGISTRY.put(ProtocolVersion.V1_21_6, v1216);
+
+        //for Protocol 771 nothing changed
+        REGISTRY.put(ProtocolVersion.V1_21_7, v1216);
     }
 
     /**

--- a/src/main/java/de/t0bx/sentienceEntity/network/version/registries/PacketIdRegistry.java
+++ b/src/main/java/de/t0bx/sentienceEntity/network/version/registries/PacketIdRegistry.java
@@ -55,18 +55,25 @@ public class PacketIdRegistry {
         v1214.put(PacketId.SET_PLAYER_TEAM, 0x67);
         REGISTRY.put(ProtocolVersion.V1_21_4, v1214);
 
-        var v1215 = new EnumMap<PacketId, Integer>(PacketId.class);
-        v1215.put(PacketId.PLAYER_INFO_UPDATE, 0x3F);
-        v1215.put(PacketId.PLAYER_INFO_REMOVE, 0x3E);
-        v1215.put(PacketId.SPAWN_ENTITY, 0x01);
-        v1215.put(PacketId.SET_ENTITY_METADATA, 0x5C);
-        v1215.put(PacketId.SET_HEAD_ROTATION, 0x4C);
-        v1215.put(PacketId.UPDATE_ENTITY_ROTATION, 0x31);
-        v1215.put(PacketId.REMOVE_ENTITY, 0x46);
-        v1215.put(PacketId.TELEPORT_ENTITY, 0x1F);
-        v1215.put(PacketId.INTERACT_ENTITY, 0x18);
-        v1215.put(PacketId.SET_PLAYER_TEAM, 0x66);
+        var v1215 = cloneWithChanges(v1214, Map.of(
+                PacketId.PLAYER_INFO_UPDATE, 0x3F,
+                PacketId.PLAYER_INFO_REMOVE, 0x3E,
+                PacketId.SET_ENTITY_METADATA, 0x5C,
+                PacketId.SET_HEAD_ROTATION, 0x4C,
+                PacketId.UPDATE_ENTITY_ROTATION, 0x31,
+                PacketId.REMOVE_ENTITY, 0x46,
+                PacketId.TELEPORT_ENTITY, 0x1F,
+                PacketId.SET_PLAYER_TEAM, 0x66
+        ));
         REGISTRY.put(ProtocolVersion.V1_21_5, v1215);
+
+        var v1216 = cloneWithChanges(v1215, Map.of(
+                PacketId.INTERACT_ENTITY, 0x19
+        ));
+        REGISTRY.put(ProtocolVersion.V1_21_6, v1216);
+
+        // No changes for 1_21_7 from 1_21_6
+        REGISTRY.put(ProtocolVersion.V1_21_7, v1216);
     }
 
     /**
@@ -86,5 +93,12 @@ public class PacketIdRegistry {
             throw new IllegalArgumentException("No packet mapping for packet id " + packetId + " in version " + version);
         }
         return map.get(packetId);
+    }
+
+    private static EnumMap<PacketId, Integer> cloneWithChanges(EnumMap<PacketId, Integer> base,
+                                                               Map<PacketId, Integer> changes) {
+        var clone = new EnumMap<>(base);
+        clone.putAll(changes);
+        return clone;
     }
 }

--- a/src/main/java/de/t0bx/sentienceEntity/network/wrapper/packets/PacketSetHeadRotation.java
+++ b/src/main/java/de/t0bx/sentienceEntity/network/wrapper/packets/PacketSetHeadRotation.java
@@ -68,6 +68,7 @@ public class PacketSetHeadRotation implements PacketWrapper {
         ByteBuf buf = Unpooled.buffer();
 
         PacketUtils.writeVarInt(buf, packetId);
+
         PacketUtils.writeVarInt(buf, entityId);
         PacketUtils.writeAngle(buf, headYaw);
 

--- a/src/main/java/de/t0bx/sentienceEntity/network/wrapper/packets/PacketUpdateEntityRotation.java
+++ b/src/main/java/de/t0bx/sentienceEntity/network/wrapper/packets/PacketUpdateEntityRotation.java
@@ -74,6 +74,7 @@ public class PacketUpdateEntityRotation implements PacketWrapper {
         ByteBuf buf = Unpooled.buffer();
 
         PacketUtils.writeVarInt(buf, packetId);
+
         PacketUtils.writeVarInt(buf, entityId);
         PacketUtils.writeAngle(buf, yaw);
         PacketUtils.writeAngle(buf, pitch);

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: SentienceEntity
-version: '1.6'
+version: '1.7'
 main: de.t0bx.sentienceEntity.SentienceEntity
 api-version: '1.21'
 authors: [ t0bx ]


### PR DESCRIPTION
Updated the plugin version to 1.7, including corresponding changes in `pom.xml`, `README.md`, and `plugin.yml`. Added support for Protocol 1.21.6 and 1.21.7 in registries and packet handling. Introduced minor refactoring for better maintainability in `PacketIdRegistry`.